### PR TITLE
regress: Fix compatibility with PostgreSQL 12

### DIFF
--- a/sql/circle.sql
+++ b/sql/circle.sql
@@ -1,5 +1,6 @@
 \set ECHO none
 SELECT set_sphere_output_precision(8);
+SET extra_float_digits = 0;
 \set ECHO all
 
 -- Input/Output ---

--- a/sql/poly.sql
+++ b/sql/poly.sql
@@ -1,5 +1,6 @@
 \set ECHO none
 SELECT set_sphere_output_precision(8);
+SET extra_float_digits = 0;
 \set ECHO all
 
 -- checking polygon operators


### PR DESCRIPTION
PostgreSQL has more floating point output precision by default, this
changes the regression tests to request the old format.